### PR TITLE
Controls to have classes other than "form-control"

### DIFF
--- a/django_forms_bootstrap/templatetags/bootstrap_tags.py
+++ b/django_forms_bootstrap/templatetags/bootstrap_tags.py
@@ -10,7 +10,10 @@ def _preprocess_fields(form):
     for field in form.fields:
         name = form.fields[field].widget.__class__.__name__.lower()
         if not name.startswith("radio") and not name.startswith("checkbox"):
-            form.fields[field].widget.attrs["class"] = " form-control"
+            try:
+                form.fields[field].widget.attrs["class"] += " form-control"
+            except KeyError:
+                form.fields[field].widget.attrs["class"] = " form-control"
     return form
 
 


### PR DESCRIPTION
Quick and dirty fix erasing custom css classes assigned to form controls
