### PR TITLE
Fix and improve errors messages

### DIFF
--- a/django_forms_bootstrap/templates/bootstrap/form.html
+++ b/django_forms_bootstrap/templates/bootstrap/form.html
@@ -5,9 +5,11 @@
         {% if form_error_title %}
         <strong>{{ form_error_title }}</strong><br />
         {% endif %}
-        {% for error in form.non_field_errors %}
-            {{ error }}<br />
-        {% endfor %}
+        {% if form.non_field_errors|length == 1 %}
+        {{ form.non_field_errors|first }}
+        {% else %}
+        {{ form.non_field_errors }}
+        {% endif %}
     </div>
 {% endif %}
 


### PR DESCRIPTION
- bs-callout is not part of bootstrap (but can be found in the css of the doc - if you really want to use it, you probably should include the relevant part in the form media field) (see https://github.com/twbs/bootstrap/pull/8296#issuecomment-26306284 for the relevant part)
- print errors messages as a list using ul/li if there are severals
