### PR TITLE
Update README.rst to include relevant template filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,17 +49,17 @@ and include your form using something like the following markup: ::
 Specifying form layouts
 -----------------------
 
-Bootstrap includes styles for four types of forms. To change the display of
-your form, add one of the following class attributes to your form tag:
+Bootstrap includes styles for three types of forms. To change the display of
+your form, add one of the following class attributes to your form tag and
+use the appropriate template filter:
 
-==================  ================   ==============================================================
-        Name             Class                        Description
-==================  ================   ==============================================================
-Vertical (default)  .form-vertical     Stacked, left-aligned labels over controls
-Horizontal          .form-horizontal   Float left, right-aligned labels on same line as controls
-Inline              .form-inline       Left-aligned label and inline-block controls for compact style
-Search              .form-search       Extra-rounded text input for a typical search aesthetic
-==================  ================   ==============================================================
+================   ======================================   ========================================
+    Class          Template filter                                Description
+================   ======================================   ========================================
+.form-vertical     ``{{ form|as_bootstrap }}``              Labels over controls (default)
+.form-horizontal   ``{{ form|as_bootstrap_horizontal }}``   Labels on same line as controls
+.form-inline       ``{{ form|as_bootstrap_inline }}``       Compact style with inline-block controls
+================   ======================================   ========================================
 
 
 License & Attribution


### PR DESCRIPTION
We recently used this library at Twilio in a new how-to on our docs site. You can view it [here](http://twiliodeved.github.io/appointment-reminders-django/) now and on twilio.com sometime next week.

I wanted to use a horizontal form but it took a little sleuthing to find the right template filter I should use with django-forms-bootstrap.

This PR updates the README to include those template filters.

To fit it in I condensed the table a little, swapping out the "Name" column with a new "Template filter" column. I also removed the reference to `.form-search`, since its not part of Bootstrap 3 and doesn't require any special django-forms-bootstrap changes if you want to use it with Bootstrap 2 anyway.

Thanks for maintaining such a handy library! It was perfect for what we needed in this tutorial.