### PR TITLE
deprecation warning for rendering templates

### DIFF
--- a/django_forms_bootstrap/templatetags/bootstrap_tags.py
+++ b/django_forms_bootstrap/templatetags/bootstrap_tags.py
@@ -22,9 +22,9 @@ def as_bootstrap(form):
     template = get_template("bootstrap/form.html")
     form = _preprocess_fields(form)
 
-    c = Context({
+    c = {
         "form": form,
-    })
+    }
     return template.render(c)
 
 
@@ -44,10 +44,10 @@ def as_bootstrap_inline(form):
         "wrap": "",
     }
 
-    c = Context({
+    c = {
         "form": form,
         "css_classes": css_classes,
-    })
+    }
     return template.render(c)
 
 
@@ -81,10 +81,10 @@ def as_bootstrap_horizontal(form, label_classes=""):
             css_classes["single_container"] += offset_class + " " + wrap_class + " "
             css_classes["wrap"] += wrap_class + " "
 
-    c = Context({
+    c = {
         "form": form,
         "css_classes": css_classes,
-    })
+    }
     return template.render(c)
 
 


### PR DESCRIPTION
Per [https://code.djangoproject.com/ticket/25854](https://code.djangoproject.com/ticket/25854), `template.render()` should use a dict, not a Context object.  Apparently this behavior changed in 1.8, but wasn't a noisy warning until 1.9.  This is the error I was getting, using `as_bootstrap`:

```
RemovedInDjango110Warning: render() must be called with a dict, not a RequestContext.
```

I changed the Context objects to be plain dicts.
