### PR TITLE
Properly set CSS classes on file inputs

### DIFF
--- a/django_forms_bootstrap/templatetags/bootstrap_tags.py
+++ b/django_forms_bootstrap/templatetags/bootstrap_tags.py
@@ -16,7 +16,7 @@ register = template.Library()
 def _preprocess_fields(form):
     for field in form.fields:
         name = form.fields[field].widget.__class__.__name__.lower()
-        if not name.startswith("radio") and not name.startswith("checkbox"):
+        if not name.startswith("radio") and not name.startswith("checkbox") and not name.endswith('fileinput'):
             try:
                 form.fields[field].widget.attrs["class"] += " form-control"
             except KeyError:


### PR DESCRIPTION
It fixes #25. 

According to [Bootstrap](https://getbootstrap.com/docs/3.3/css/#forms-example), file inputs have not got form-control class. I have extended the existing condition to cover Django's FileInput and ClearableFileInput widget names.