### PR TITLE
change context_class to dict when django_version is greater than 1.8 to resolve deprecation warning

### DIFF
--- a/django_forms_bootstrap/templatetags/bootstrap_tags.py
+++ b/django_forms_bootstrap/templatetags/bootstrap_tags.py
@@ -3,7 +3,7 @@ from django.template.loader import get_template
 from django import VERSION as DJANGO_VERSION
 
 
-if DJANGO_VERSION >= (1, 10, 0):
+if DJANGO_VERSION >= (1, 8, 0):
     context_class = dict
 else:
     # Django<1.10 compatibility


### PR DESCRIPTION
- Projects that are using django1.8 receive unnecessary deprecation warnings while having the latest version of django-forms-bootstrap